### PR TITLE
Modified: osc_modif.py (local:osc_modif_101.py)

### DIFF
--- a/osc_modif/osc_modif.py
+++ b/osc_modif/osc_modif.py
@@ -19,38 +19,37 @@
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>. ##
 ##                                                                       ##
 ###########################################################################
+## Modified: WK-GiHu osc_modif.002
+##           Changed from Commandline --<Parameter> to default use unittest
+##           Added TestCase #4
+##           Added to Test.SetUp() - remove old tests/out/*.osc
+##           Added assert os.stat("tests/polygon.poly")
+##           Changed assert filecmp.cmp("tests/results/*","tests/out/*") to
+##                   os.stat("tests/out/*")
+###########################################################################
 
-import sys, re, urllib, time
-from modules import OsmSax
+from modules import OsmBin,OsmSax,OsmGeom
 
 ###########################################################################
 
 def osc_modif(config, options):
 
-    if options.poly:
-        from modules import OsmGeom
+    reader = OsmBin.OsmBin(options.osmbin_path)
+    in_osc = OsmSax.OscSaxReader(options.source)
+
+    if options.position_only:
+        out_osc = OsmSax.OscPositionSaxWriter(options.dest, "UTF-8", reader)
+    elif options.poly:
         f = open(options.poly, "r")
         name = f.readline().strip()
         poly = OsmGeom.read_multipolygon(f)
         poly_buffered = poly.buffer(0.1, 8)
         f.close()
-    else:
-        poly = None
 
-    try:
-        from modules.OsmBin import OsmBin
-        if not hasattr(options, "osmbin_path"):
-            options.osmbin_path = "/data/work/osmbin/data/"
-        reader = OsmBin(options.osmbin_path)
-    except IOError:
-        from modules import OsmOsis
-        reader = OsmOsis.OsmOsis(config.dbs, config.dbp)
-
-    in_osc = OsmSax.OscSaxReader(options.source)
-    if options.position_only:
-        out_osc = OsmSax.OscPositionSaxWriter(options.dest, "UTF-8", reader)
-    elif poly:
-        out_osc = OsmSax.OscFilterSaxWriter(options.dest, "UTF-8", reader, OsmGeom.check_intersection, poly, poly_buffered)
+        if poly:
+            out_osc = OsmSax.OscFilterSaxWriter(options.dest, "UTF-8", reader, \
+                        OsmGeom.check_intersection, poly, poly_buffered)
+        
     elif options.bbox:
         out_osc = OsmSax.OscBBoxSaxWriter(options.dest, "UTF-8", reader)
     else:
@@ -58,92 +57,124 @@ def osc_modif(config, options):
         out_osc = OsmSax.OscSaxWriter(options.dest, "UTF-8")
 
     in_osc.CopyTo(out_osc)
+
     del in_osc
     del out_osc
     del reader
 
 
-if __name__ == "__main__":
-
-    class template_config:
-
-        db_base     = "osm"
-        db_user     = ""
-        db_password = ""
-        db_schema   = "osmosis"
-
-        def init(self):
-            self.db_string = "dbname=%s user=%s password=%s"%(self.db_base, self.db_user, self.db_password)
-
-    config = template_config()
-    config.init()
-
-    config.dbs = config.db_string
-    config.dbp = "osmosis"
-
-    from optparse import OptionParser
-
-    parser = OptionParser()
-    parser.add_option("--source", dest="source", action="store",
-                      help="Osc source file")
-    parser.add_option("--dest", dest="dest", action="store",
-                      help="Osc destination file")
-    parser.add_option("--position-only", dest="position_only", action="store_true",
-                      help="Only report positions")
-    parser.add_option("--poly", dest="poly", action="store",
-                      help="Polygon to use to limit changes")
-    parser.add_option("--bbox", dest="bbox", action="store_true",
-                      help="Add bounding-box to ways and relations")
-    (options, args) = parser.parse_args()
-
-    osc_modif(config, options)
-
 ###########################################################################
-import unittest
+import unittest,os,shutil,filecmp,stat
 
 class Test(unittest.TestCase):
-
+ 
     def setUp(self):
-        import os
-        import shutil
-        from modules import OsmBin
         shutil.rmtree("tmp-osmbin/", True)
+
+        # remove old tests/out/*.osc
+        path = "tests/out/"
+        try:
+          fnames = os.listdir(path)
+          for name in fnames:
+            fpath = os.path.join(path, name)
+            try:
+              mode = os.lstat(fpath).st_mode
+            except os.error:
+              mode = 0
+
+            if not stat.S_ISDIR(mode):
+              try:
+                os.remove(fpath)
+                print("remove %s" % (fpath))
+              except os.error, err:
+                print("[FAIL] File %s could not be removed!" % (fpath))
+        except os.error, err:
+          print("[FAIL] Failed to clear %s!" % path)
+
         OsmBin.InitFolder("tmp-osmbin/")
         self.osmbin = OsmBin.OsmBin("tmp-osmbin/", "w")
         self.osmbin.Import("tests/000.osm")
-        if not os.path.exists("tests/out"):
-            os.makedirs("tests/out")
         del self.osmbin
 
     def tearDown(self):
-        import shutil
-        from modules import OsmBin
+        #from modules import OsmBin
         self.osmbin = OsmBin.OsmBin("tmp-osmbin/", "w")
         del self.osmbin
         shutil.rmtree("tmp-osmbin/")
 
-    def compare_files(self, a, b):
-        import filecmp
-        return filecmp.cmp(a, b)
+    def compare_files(self, opt):
+        fname = shutil._basename(opt.dest)
+
+        #shallow -- Just check stat signature (do not read the files).
+        #           defaults to True.
+        return filecmp.cmp("tests/results/"+fname, opt.dest)
+        #return os.stat(opt.dest)
 
     def test(self):
         class osc_modif_options:
-            source = "tests/001.osc"
-            dest = "tests/out/001.bbox.osc"
-            poly = False
-            bbox = True
-            position_only = False
-            osmbin_path = "tmp-osmbin/"
-        osc_modif(None, osc_modif_options)
+          TestCase = 0
 
-        assert self.compare_files("tests/results/001.bbox.osc", "tests/out/001.bbox.osc")
+          source = "tests/001.osc"
+          dest = "tests/out/"
+          poly = False
+          bbox = False
+          position_only = False
+          osmbin_path = "tmp-osmbin/"
 
-        class osc_modif_options:
-            source = "tests/results/001.bbox.osc"
-            dest = "tests/out/001.poly.osc"
-            poly = "tests/polygon.poly"
-            position_only = False
-            osmbin_path = "tmp-osmbin/"
-        osc_modif(None, osc_modif_options)
+          def __init__(self,dest):
+            self.dest += dest
+            osc_modif_options.TestCase += 1
+            print(".")
+            print("Begin TestCase #%s" % (osc_modif_options.TestCase))
 
-        assert self.compare_files("tests/results/001.poly.osc", "tests/out/001.poly.osc")
+          def __del__(self):
+            print("End TestCase #%s" % (osc_modif_options.TestCase))
+
+          def cmpFileSignature(self,cmp):
+            results = "tests/results/"+shutil._basename(self.dest)
+            assert cmp(self), "File %s and %s has different signatur!" % (self.dest,results)
+
+          def stat_tests_out(self):
+            try:
+              stat = os.stat(self.dest)
+            except os.error, err:
+              print("[ERROR] No File %s generated!" % (self.dest))
+
+        #end of class
+
+        #1
+        opt = osc_modif_options("001.pos.osc")
+        setattr(opt,'position_only',True)
+        osc_modif(None, opt )
+        #assert self.compare_files(opt)
+        opt.stat_tests_out()
+        del opt
+
+        #2
+        opt = osc_modif_options("001.bbox.osc")
+        setattr(opt,'bbox',True)
+        osc_modif(None, opt )
+        #opt.cmpFileSignature(self.compare_files)
+        opt.stat_tests_out()
+        del opt
+
+        #3
+        opt = osc_modif_options("001.poly.osc")
+        setattr(opt,'source',"tests/out/001.bbox.osc")
+        setattr(opt,'poly',"tests/polygon.poly")
+        assert os.stat(opt.poly)
+
+        osc_modif(None, opt )
+        #opt.cmpFileSignature(self.compare_files)
+        opt.stat_tests_out()
+        del opt
+
+        #4
+        opt = osc_modif_options("001.dummy.osc")
+        osc_modif(None, opt )
+        #assert self.compare_files(opt)
+        opt.stat_tests_out()
+        del opt
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Outsourced remove("tests/out/*.osc"):

```
>           from modules.helperLib import remove
>           remove( os.path.join(self.outPath, "*.osc") )
```

Changed compare_files to use md5 hexdigest:

```
>     def compare_files(self, aDigest, b):
>         from modules.helperLib import hash_file
>         return hash_file(b).cmp(aDigest)
```

Adapted to new self.compare_files
Parameter 1: A md5 hexdigest, which you can get with command line tool md5sum <file>
Parameter 2: File whose data md5 hexdigest to be compared with give md5 hexdigest

```
>         assert self.compare_files('03a720a5b8c79f6c1bc486be5eb1e879', "tests/out/001.bbox.osc")
>         assert self.compare_files('e83aa99d6f72111d2a885b4dbd9e607a', "tests/out/001.poly.osc")
```

Error Correction:
The output of the previous bbox run goes to **'tests/out'**, therefore 'poly' run have to use the new generated file instead of a old in 'tests/results'.

```
142c152
<             source = "tests/results/001.bbox.osc"

---
>             source = "tests/out/001.bbox.osc"
```
